### PR TITLE
feat: NIOPosix compiles to wasm

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "lldb.library": "/Library/Developer/Toolchains/swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-20-a.xctoolchain/System/Library/PrivateFrameworks/LLDB.framework/Versions/A/LLDB",
+    "lldb.launch.expressions": "native",
+    "swift.path": "/Library/Developer/Toolchains/swift-6.1-DEVELOPMENT-SNAPSHOT-2025-03-20-a.xctoolchain/usr/bin",
+    "swift.swiftEnvironmentVariables": {
+        "DEVELOPER_DIR": "/Applications/Xcode.app"
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,53 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "swift",
+            "args": [
+                "build",
+                "--swift-sdk",
+                "6.1-SNAPSHOT-2025-03-20-a-wasm32-unknown-wasip1-threads",
+                "--target",
+                "NIOPosix",
+                "-Xswiftc",
+                "-diagnostic-style=llvm",
+                // SM: NOTE: The following aren't needed as long as they are copy-pasted in the NIOPosix module as well, when building NIOPosix
+                // "-Xcc",
+                // "-D__wasilibc_use_wasip2"
+            ],
+            "env": {
+                "DEVELOPER_DIR": "/Applications/Xcode.app"
+            },
+            "cwd": "/Users/scottm/git/ThirdParty/swift-nio",
+            "disableTaskQueue": true,
+            "group": "build",
+            "problemMatcher": [],
+            "label": "swift-wasm: Build NIOPosix",
+            "detail": "SCOTT: swift build --swift-sdk 6.1-SNAPSHOT-2025-03-20-a-wasm32-unknown-wasip1-threads --target NIOPosix"
+        },
+        {
+            "type": "swift",
+            "args": [
+                "build",
+                "--swift-sdk",
+                "6.1-SNAPSHOT-2025-03-20-a-wasm32-unknown-wasip1-threads",
+                "--product",
+                "NIOWebSocketClient",
+                "-Xswiftc",
+                "-diagnostic-style=llvm",
+                // SM: NOTE: The following aren't needed as long as they are copy-pasted in the NIOPosix module as well, when building NIOPosix
+                // "-Xcc",
+                // "-D__wasilibc_use_wasip2"
+            ],
+            "env": {
+                "DEVELOPER_DIR": "/Applications/Xcode.app"
+            },
+            "cwd": "/Users/scottm/git/ThirdParty/swift-nio",
+            "disableTaskQueue": true,
+            "group": "build",
+            "problemMatcher": [],
+            "label": "swift-wasm: Build NIOWebSocketClient",
+            "detail": "SCOTT: swift build --swift-sdk 6.1-SNAPSHOT-2025-03-20-a-wasm32-unknown-wasip1-threads --product NIOWebSocketClient"
+        }
+    ]
+}

--- a/Package.swift
+++ b/Package.swift
@@ -114,6 +114,7 @@ let package = Package(
                 "CNIOLinux",
                 "CNIODarwin",
                 "CNIOWindows",
+                "CNIOWASI",
                 "NIOConcurrencyHelpers",
                 "NIOCore",
                 "_NIODataStructures",
@@ -121,6 +122,18 @@ let package = Package(
             ],
             exclude: includePrivacyManifest ? [] : ["PrivacyInfo.xcprivacy"],
             resources: includePrivacyManifest ? [.copy("PrivacyInfo.xcprivacy")] : [],
+
+            // SM: We will need to make these conditional on wasi, and include on all
+            // configs that can consume CNIOWASI.
+            cSettings: [
+                // SM: Ask Max about this. Is this ok?
+                .define("__wasilibc_use_wasip2"),
+
+                .define("_GNU_SOURCE")
+//                .unsafeFlags([
+//                    "-Xcc", "-D__wasilibc_use_wasip2"
+//                ])
+            ],
             swiftSettings: strictConcurrencySettings
         ),
         .target(
@@ -179,7 +192,16 @@ let package = Package(
         ),
         .target(
             name: "CNIOWASI",
-            dependencies: []
+            dependencies: [],
+            cSettings: [
+                // SM: Ask Max about this. Is this ok?
+                .define("__wasilibc_use_wasip2"),
+
+                .define("_GNU_SOURCE"),
+//                .unsafeFlags([
+//                    "-Xcc", "-D__wasilibc_use_wasip2"
+//                ])
+            ]
         ),
         .target(
             name: "NIOConcurrencyHelpers",

--- a/Sources/CNIOWASI/include/CNIOWASI.h
+++ b/Sources/CNIOWASI/include/CNIOWASI.h
@@ -12,12 +12,44 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+// TODO: SM: Find all places I'm using this and see if import wasilibc will work instead. Should default to that first
+
+// TODO: SM: Make a pass through all the CNIOLinux usages and make sure I'm not missing some #if changes anywhere
+
+// TODO: SM: See if any unit test can be enabled, figure out how to compile and run them.
+
+// TODO: SM: Make usage readme for wasm usage (with compiler flags) and table of what works and what doesn't in wasm builds.
+
+#ifndef C_NIO_WASI_H
+#define C_NIO_WASI_H
 
 #if __wasi__
 
+#include <sys/socket.h>
 #include <fcntl.h>
 #include <time.h>
+
+#include <pthread.h>
+#include <threads.h>
+#include <sched.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+#include <assert.h>
+#include <time.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <dlfcn.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <limits.h>
+#include <bits/dirent.h>
+#include <bits/signal.h>
+
+// TODO: Figure out how to get WASI_EMULATED_SIGNAL to compile. The .a lib is there in the swift wasm wasilibc
+// Once this is figured out, `BaseSocketProtocol.ignoreSIGPIPE` can be implemented.
+// #include <signal.h>
 
 static inline void CNIOWASI_gettime(struct timespec *tv) {
     // ClangImporter doesn't support `CLOCK_MONOTONIC` declaration in WASILibc, thus we have to define a bridge manually
@@ -29,4 +61,75 @@ static inline int CNIOWASI_O_CREAT() {
     return O_CREAT;
 }
 
-#endif
+// Some explanation is required here.
+//
+// Due to SR-6772, we cannot get Swift code to directly see any of the mmsg structures or
+// functions. However, we *can* get C code built by SwiftPM to see them. For this reason we
+// elect to provide a selection of shims to enable Swift code to use recv_mmsg and send_mmsg.
+// Mostly this is fine, but to minimise the overhead we want the Swift code to be able to
+// create the msgvec directly without requiring further memory fussiness in our C shim.
+// That requires us to also construct a C structure that has the same layout as struct mmsghdr.
+//
+// Conveniently glibc has pretty strict ABI stability rules, and this structure is part of the
+// glibc ABI, so we can just reproduce the structure definition here and feel confident that it
+// will be sufficient.
+//
+// If SR-6772 ever gets resolved we can remove this shim.
+//
+// https://bugs.swift.org/browse/SR-6772
+
+// https://github.com/WebAssembly/wasi-libc/blob/09683b3623ec49f79899fc1d847f29e26af80fd1/libc-top-half/musl/include/sys/socket.h#L71
+typedef struct {
+    struct msghdr msg_hdr;
+    unsigned int msg_len;
+} CNIOWASI_mmsghdr;
+
+
+// NOTE: Scott Marchant, March 26, 2025:
+//
+// The following struct is elided by a #ifdef __wasilibc_unmodified_upstream in socket.h.
+// For now, we're just copy-pasting these definitions since there doesn't appear to be an
+// actual limitation in the WASI spec prohibiting the definition of this message structure.
+
+// Begin copy-paste-adapation
+struct cmsghdr {
+	socklen_t cmsg_len;
+	int cmsg_level;
+	int cmsg_type;
+};
+// End copy-paste
+
+int CNIOWASI_sendmmsg(int sockfd, CNIOWASI_mmsghdr *msgvec, unsigned int vlen, unsigned int flags);
+int CNIOWASI_recvmmsg(int sockfd, CNIOWASI_mmsghdr *msgvec, unsigned int vlen, unsigned int flags, struct timespec *timeout);
+
+const char* CNIOWASI_dirent_dname(struct dirent* ent);
+
+// FCNTL bit-field define passthroughs
+extern const int CNIOWASI_O_APPEND;
+extern const int CNIOWASI_O_SYNC;
+extern const int CNIOWASI_O_NONBLOCK;
+
+// Socket option passthroughs
+extern const int CNIOWASI_SO_REUSEADDR;
+extern const int CNIOWASI_SO_ERROR;
+extern const int CNIOWASI_SO_SNDBUF;
+extern const int CNIOWASI_SO_RCVBUF;
+extern const int CNIOWASI_SO_KEEPALIVE;
+extern const int CNIOWASI_SO_ACCEPTCONN;
+extern const int CNIOWASI_SO_PROTOCOL;
+extern const int CNIOWASI_SO_DOMAIN;
+extern const int CNIOWASI_SO_RCVTIMEO;
+
+extern const int CNIOWASI_SOCK_DGRAM;
+extern const int CNIOWASI_SOCK_STREAM;
+
+// cmsghdr handling
+struct cmsghdr *CNIOWASI_CMSG_FIRSTHDR(const struct msghdr *);
+struct cmsghdr *CNIOWASI_CMSG_NXTHDR(struct msghdr *, struct cmsghdr *);
+const void *CNIOWASI_CMSG_DATA(const struct cmsghdr *);
+void *CNIOWASI_CMSG_DATA_MUTABLE(struct cmsghdr *);
+size_t CNIOWASI_CMSG_LEN(size_t);
+size_t CNIOWASI_CMSG_SPACE(size_t);
+
+#endif // __wasi__
+#endif // C_NIO_WASI_H

--- a/Sources/CNIOWASI/include/CNIOWASI.h
+++ b/Sources/CNIOWASI/include/CNIOWASI.h
@@ -47,6 +47,253 @@
 #include <bits/dirent.h>
 #include <bits/signal.h>
 
+// TODO: SM: Remove notes about importable headers below
+
+// // All below (c posix lib) compiles with 0.2
+// #include <assert.h>
+// #include <complex.h>
+// #include <ctype.h>
+// #include <dirent.h>
+// #include <dlfcn.h>
+// #include <errno.h>
+// #include <fcntl.h>
+// #include <fenv.h>
+// #include <float.h>
+// #include <inttypes.h>
+// #include <iso646.h>
+// #include <limits.h>
+// #include <locale.h>
+// #include <math.h>
+// #include <pthread.h>
+// // #include <setjmp.h> // No in WASI 0.2
+// // #include <signal.h> // No in WASI 0.2, but there is emulated signal support
+// #include <stdarg.h>
+// #include <stdbool.h>
+// #include <stddef.h>
+// #include <stdint.h>
+// #include <stdio.h>
+// #include <stdlib.h>
+// #include <string.h>
+// #include <sys/stat.h>
+// #include <tgmath.h>
+// #include <time.h>
+// #include <unistd.h>
+// #include <utime.h>
+// #include <wchar.h>
+// #include <wctype.h>
+// 
+// #include <sys/socket.h>
+
+// // All below (c posix lib) compiles with 0.2
+// // #include <aio.h>
+// #include <arpa/inet.h>
+// #include <assert.h>
+// #include <complex.h>
+// #include <cpio.h>
+// #include <ctype.h>
+// #include <dirent.h>
+// #include <dlfcn.h>
+// #include <errno.h>
+// #include <fcntl.h>
+// #include <fenv.h>
+// #include <float.h>
+// #include <fmtmsg.h>
+// #include <fnmatch.h>
+// #include <ftw.h>
+// #include <glob.h>
+// // #include <grp.h> // No
+// #include <iconv.h>
+// #include <inttypes.h>
+// #include <iso646.h>
+// #include <langinfo.h>
+// #include <libgen.h>
+// #include <limits.h>
+// #include <locale.h>
+// #include <math.h>
+// #include <monetary.h>
+// #include <mqueue.h>
+// // #include <ndbm.h> // No
+// // #include <net/if.h> // No
+// // #include <netdb.h> // No
+// #include <netinet/in.h>
+// #include <netinet/tcp.h>
+// #include <nl_types.h>
+// #include <poll.h>
+// #include <pthread.h>
+// // #include <pwd.h> // No
+// #include <regex.h>
+// #include <sched.h>
+// #include <search.h>
+// #include <semaphore.h>
+// // #include <setjmp.h> // No
+// // #include <signal.h> // No
+// // #include <spawn.h> // No
+// #include <stdarg.h>
+// #include <stdbool.h>
+// #include <stddef.h>
+// #include <stdint.h>
+// #include <stdio.h>
+// #include <stdlib.h>
+// #include <string.h>
+// #include <strings.h>
+// #include <stropts.h>
+// // #include <sys/ipc.h> // No
+// // #include <sys/mman.h> // No
+// // #include <sys/msg.h> // No
+// // #include <sys/resource.h> // No
+// #include <sys/select.h>
+// // #include <sys/sem.h> // No
+// // #include <sys/shm.h> // No
+// #include <sys/socket.h>
+// #include <sys/stat.h>
+// #include <sys/statvfs.h>
+// #include <sys/time.h>
+// // #include <sys/times.h> // No
+// #include <sys/types.h>
+// #include <sys/uio.h>
+// #include <sys/un.h>
+// #include <sys/utsname.h>
+// // #include <sys/wait.h> // No
+// // #include <syslog.h> // No
+// #include <tar.h>
+// // #include <termios.h> // No
+// #include <tgmath.h>
+// #include <time.h>
+// // #include <trace.h> // No
+// // #include <ulimit.h> // No
+// #include <unistd.h>
+// #include <utime.h>
+// // #include <utmpx.h> // No
+// #include <wchar.h>
+// #include <wctype.h>
+// // #include <wordexp.h> // No
+
+
+
+// // All below (c posix lib) compiles with 0.1
+// #include <assert.h>
+// #include <complex.h>
+// #include <ctype.h>
+// #include <dirent.h>
+// #include <dlfcn.h>
+// #include <errno.h>
+// #include <fcntl.h>
+// #include <fenv.h>
+// #include <float.h>
+// #include <inttypes.h>
+// #include <iso646.h>
+// #include <limits.h>
+// #include <locale.h>
+// #include <math.h>
+// #include <pthread.h>
+// // #include <setjmp.h> // No in WASI 0.1
+// // #include <signal.h> // No in WASI 0.1
+// #include <stdarg.h>
+// #include <stdbool.h>
+// #include <stddef.h>
+// #include <stdint.h>
+// #include <stdio.h>
+// #include <stdlib.h>
+// #include <string.h>
+// #include <sys/stat.h>
+// #include <tgmath.h>
+// #include <time.h>
+// #include <unistd.h>
+// #include <utime.h>
+// #include <wchar.h>
+// #include <wctype.h>
+// 
+// #include <sys/socket.h> // No in WASI 0.1
+
+// // All below (c posix lib) compiles with 0.1
+// // #include <aio.h> // No
+// #include <arpa/inet.h>
+// #include <assert.h>
+// #include <complex.h>
+// #include <cpio.h>
+// #include <ctype.h>
+// #include <dirent.h>
+// #include <dlfcn.h>
+// #include <errno.h>
+// #include <fcntl.h>
+// #include <fenv.h>
+// #include <float.h>
+// #include <fmtmsg.h>
+// #include <fnmatch.h>
+// #include <ftw.h>
+// #include <glob.h>
+// // #include <grp.h> // No
+// #include <iconv.h>
+// #include <inttypes.h>
+// #include <iso646.h>
+// #include <langinfo.h>
+// #include <libgen.h>
+// #include <limits.h>
+// #include <locale.h>
+// #include <math.h>
+// #include <monetary.h>
+// #include <mqueue.h>
+// // #include <ndbm.h> // No
+// // #include <net/if.h> // No
+// // #include <netdb.h> // No
+// #include <netinet/in.h>
+// #include <netinet/tcp.h>
+// #include <nl_types.h>
+// #include <poll.h>
+// #include <pthread.h>
+// // #include <pwd.h> // No
+// #include <regex.h>
+// #include <sched.h>
+// #include <search.h>
+// #include <semaphore.h>
+// // #include <setjmp.h> // No
+// // #include <signal.h> // No
+// // #include <spawn.h> // No
+// #include <stdarg.h>
+// #include <stdbool.h>
+// #include <stddef.h>
+// #include <stdint.h>
+// #include <stdio.h>
+// #include <stdlib.h>
+// #include <string.h>
+// #include <strings.h>
+// #include <stropts.h>
+// // #include <sys/ipc.h> // No
+// // #include <sys/mman.h> // No
+// // #include <sys/msg.h> // No
+// // #include <sys/resource.h> // No
+// #include <sys/select.h>
+// // #include <sys/sem.h> // No
+// // #include <sys/shm.h> // No
+// #include <sys/socket.h>
+// #include <sys/stat.h>
+// #include <sys/statvfs.h>
+// #include <sys/time.h>
+// // #include <sys/times.h> // No
+// #include <sys/types.h>
+// #include <sys/uio.h>
+// #include <sys/un.h>
+// #include <sys/utsname.h>
+// // #include <sys/wait.h> // No
+// // #include <syslog.h> // No
+// #include <tar.h>
+// // #include <termios.h> // No
+// #include <tgmath.h>
+// #include <time.h>
+// // #include <trace.h> // No
+// // #include <ulimit.h> // No
+// #include <unistd.h>
+// #include <utime.h>
+// // #include <utmpx.h> // No
+// #include <wchar.h>
+// #include <wctype.h>
+// // #include <wordexp.h> // No
+
+
+
+
+// foo
+
 // TODO: Figure out how to get WASI_EMULATED_SIGNAL to compile. The .a lib is there in the swift wasm wasilibc
 // Once this is figured out, `BaseSocketProtocol.ignoreSIGPIPE` can be implemented.
 // #include <signal.h>

--- a/Sources/CNIOWASI/shim.c
+++ b/Sources/CNIOWASI/shim.c
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// Xcode's Archive builds with Xcode's Package support struggle with empty .c files
+// (https://bugs.swift.org/browse/SR-12939).
+void CNIOWASI_i_do_nothing_just_working_around_a_darwin_toolchain_bug(void) {}
+
+#if __wasi__
+
+// SM: make sure gnu_source is defined
+
+#ifndef _GNU_SOURCE
+#error You must define _GNU_SOURCE
+#endif
+
+#include <CNIOWASI.h>
+
+// SM: better to import here than in the header. Otherwise you get dependency soup
+
+// #include <pthread.h>
+// #include <sched.h>
+// #include <stdio.h>
+// #include <sys/syscall.h>
+// #include <sys/utsname.h>
+// #include <unistd.h>
+// #include <assert.h>
+// #include <time.h>
+// #include <sys/ioctl.h>
+// #include <sys/stat.h>
+#include <sys/socket.h>
+
+_Static_assert(sizeof(CNIOWASI_mmsghdr) == sizeof(struct mmsghdr),
+               "sizes of CNIOWASI_mmsghdr and struct mmsghdr differ");
+
+int CNIOWASI_sendmmsg(int sockfd, CNIOWASI_mmsghdr *msgvec, unsigned int vlen, unsigned int flags) {
+    return sendmmsg(sockfd, (struct mmsghdr *)msgvec, vlen, flags);
+}
+
+int CNIOWASI_recvmmsg(int sockfd, CNIOWASI_mmsghdr *msgvec, unsigned int vlen, unsigned int flags, struct timespec *timeout) {
+    return recvmmsg(sockfd, (struct mmsghdr *)msgvec, vlen, flags, timeout);
+}
+
+const char* CNIOWASI_dirent_dname(struct dirent* ent) {
+    return ent->d_name;
+}
+
+// FCNTL bit-field define passthroughs
+const int CNIOWASI_O_APPEND = O_APPEND;
+const int CNIOWASI_O_SYNC = O_SYNC;
+const int CNIOWASI_O_NONBLOCK = O_NONBLOCK;
+
+// Socket options passthrough
+const int CNIOWASI_SO_REUSEADDR = SO_REUSEADDR;
+const int CNIOWASI_SO_ERROR = SO_ERROR;
+const int CNIOWASI_SO_SNDBUF = SO_SNDBUF;
+const int CNIOWASI_SO_RCVBUF = SO_RCVBUF;
+const int CNIOWASI_SO_KEEPALIVE = SO_KEEPALIVE;
+const int CNIOWASI_SO_ACCEPTCONN = SO_ACCEPTCONN;
+const int CNIOWASI_SO_PROTOCOL = SO_PROTOCOL;
+const int CNIOWASI_SO_DOMAIN = SO_DOMAIN;
+const int CNIOWASI_SO_RCVTIMEO = SO_RCVTIMEO;
+
+const int CNIOWASI_SOCK_DGRAM = SOCK_DGRAM;
+const int CNIOWASI_SOCK_STREAM = SOCK_STREAM;
+
+// NOTE: Scott Marchant, March 26, 2025:
+//
+// The following are elided by a #ifdef __wasilibc_unmodified_upstream in socket.h.
+// For now, we're just copy-pasting these definitions since there doesn't appear to be an
+// actual limitation in the WASI spec prohibiting the definition of this message structure.
+
+// Begin copy-paste
+#define __CMSG_LEN(cmsg) (((cmsg)->cmsg_len + sizeof(long) - 1) & ~(long)(sizeof(long) - 1))
+#define __CMSG_NEXT(cmsg) ((unsigned char *)(cmsg) + __CMSG_LEN(cmsg))
+#define __MHDR_END(mhdr) ((unsigned char *)(mhdr)->msg_control + (mhdr)->msg_controllen)
+
+#define CMSG_DATA(cmsg) ((unsigned char *) (((struct cmsghdr *)(cmsg)) + 1))
+#define CMSG_NXTHDR(mhdr, cmsg) ((cmsg)->cmsg_len < sizeof (struct cmsghdr) || \
+	__CMSG_LEN(cmsg) + sizeof(struct cmsghdr) >= __MHDR_END(mhdr) - (unsigned char *)(cmsg) \
+	? 0 : (struct cmsghdr *)__CMSG_NEXT(cmsg))
+#define CMSG_FIRSTHDR(mhdr) ((size_t) (mhdr)->msg_controllen >= sizeof (struct cmsghdr) ? (struct cmsghdr *) (mhdr)->msg_control : (struct cmsghdr *) 0)
+
+#define CMSG_ALIGN(len) (((len) + sizeof (size_t) - 1) & (size_t) ~(sizeof (size_t) - 1))
+#define CMSG_SPACE(len) (CMSG_ALIGN (len) + CMSG_ALIGN (sizeof (struct cmsghdr)))
+#define CMSG_LEN(len)   (CMSG_ALIGN (sizeof (struct cmsghdr)) + (len))
+// end copy-paste
+
+
+struct cmsghdr *CNIOWASI_CMSG_FIRSTHDR(const struct msghdr *mhdr) {
+    assert(mhdr != NULL);
+    return CMSG_FIRSTHDR(mhdr);
+}
+
+struct cmsghdr *CNIOWASI_CMSG_NXTHDR(struct msghdr *mhdr, struct cmsghdr *cmsg) {
+    assert(mhdr != NULL);
+    assert(cmsg != NULL);
+    return CMSG_NXTHDR(mhdr, cmsg);
+}
+
+const void *CNIOWASI_CMSG_DATA(const struct cmsghdr *cmsg) {
+    assert(cmsg != NULL);
+    return CMSG_DATA(cmsg);
+}
+
+void *CNIOWASI_CMSG_DATA_MUTABLE(struct cmsghdr *cmsg) {
+    assert(cmsg != NULL);
+    return CMSG_DATA(cmsg);
+}
+
+size_t CNIOWASI_CMSG_LEN(size_t payloadSizeBytes) {
+    return CMSG_LEN(payloadSizeBytes);
+}
+
+size_t CNIOWASI_CMSG_SPACE(size_t payloadSizeBytes) {
+    return CMSG_SPACE(payloadSizeBytes);
+}
+
+#endif // __wasi__

--- a/Sources/NIOCore/AsyncAwaitSupport.swift
+++ b/Sources/NIOCore/AsyncAwaitSupport.swift
@@ -36,7 +36,6 @@ extension EventLoopFuture {
     }
 }
 
-#if canImport(Dispatch)
 extension EventLoopGroup {
     /// Shuts down the event loop gracefully.
     ///
@@ -56,7 +55,6 @@ extension EventLoopGroup {
         }
     }
 }
-#endif
 
 extension EventLoopPromise {
     /// Complete a future with the result (or error) of the `async` function `body`.

--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -397,8 +397,26 @@ extension NIOBSDSocket.Option {
     public static let mptcp_info = NIOBSDSocket.Option(rawValue: 1)
 }
 
-#if !os(WASI)
 // Socket Options
+#if os(WASI)
+import CNIOWASI
+package let O_APPEND = CNIOWASI_O_APPEND
+package let O_SYNC = CNIOWASI_O_SYNC
+package let O_NONBLOCK = CNIOWASI_O_NONBLOCK
+
+package let SO_REUSEADDR = CNIOWASI_SO_REUSEADDR
+package let SO_ERROR = CNIOWASI_SO_ERROR
+package let SO_SNDBUF = CNIOWASI_SO_SNDBUF
+package let SO_RCVBUF = CNIOWASI_SO_RCVBUF
+package let SO_KEEPALIVE = CNIOWASI_SO_KEEPALIVE
+package let SO_ACCEPTCONN = CNIOWASI_SO_ACCEPTCONN
+package let SO_PROTOCOL = CNIOWASI_SO_PROTOCOL
+package let SO_DOMAIN = CNIOWASI_SO_DOMAIN
+package let SO_RCVTIMEO = CNIOWASI_SO_RCVTIMEO
+
+package let SOCK_DGRAM = CNIOWASI_SOCK_DGRAM
+package let SOCK_STREAM = CNIOWASI_SOCK_STREAM
+#endif
 extension NIOBSDSocket.Option {
     /// Get the error status and clear.
     public static let so_error = Self(rawValue: SO_ERROR)
@@ -406,8 +424,10 @@ extension NIOBSDSocket.Option {
     /// Use keep-alives.
     public static let so_keepalive = Self(rawValue: SO_KEEPALIVE)
 
+    #if !os(WASI)
     /// Linger on close if unsent data is present.
     public static let so_linger = Self(rawValue: SO_LINGER)
+    #endif
 
     /// Specifies the total per-socket buffer space reserved for receives.
     public static let so_rcvbuf = Self(rawValue: SO_RCVBUF)
@@ -421,10 +441,11 @@ extension NIOBSDSocket.Option {
     /// Allows the socket to be bound to an address that is already in use.
     public static let so_reuseaddr = Self(rawValue: SO_REUSEADDR)
 
+    #if !os(WASI)
     /// Allows the socket to send broadcast messages.
     public static let so_broadcast = Self(rawValue: SO_BROADCAST)
+    #endif
 }
-#endif
 
 #if !os(Windows) && !os(WASI)
 extension NIOBSDSocket.Option {

--- a/Sources/NIOCore/ByteBuffer-aux.swift
+++ b/Sources/NIOCore/ByteBuffer-aux.swift
@@ -16,6 +16,8 @@ import _NIOBase64
 
 #if canImport(Dispatch)
 import Dispatch
+#elseif os(WASI)
+import struct FoundationEssentials.Data // TODO: SM: Can I even use this import right now. Maybe import struct Foundation.Data instead?
 #endif
 
 extension ByteBuffer {

--- a/Sources/NIOCore/ByteBuffer-aux.swift
+++ b/Sources/NIOCore/ByteBuffer-aux.swift
@@ -303,7 +303,7 @@ extension ByteBuffer {
         }
     }
 
-    #if canImport(Dispatch)
+    #if canImport(Dispatch) || os(WASI) // TODO: SM: Figure out import scheme for canImport(Dispatch)
     // MARK: DispatchData APIs
     /// Write `dispatchData` into this `ByteBuffer`, moving the writer index forward appropriately.
     ///
@@ -709,7 +709,7 @@ extension ByteBuffer {
         self = ByteBufferAllocator().buffer(buffer: buffer)
     }
 
-    #if canImport(Dispatch)
+    #if canImport(Dispatch) || os(WASI) // TODO: SM: Figure out import scheme for canImport(Dispatch)
     /// Create a fresh `ByteBuffer` containing the bytes contained in the given `DispatchData`.
     ///
     /// This will allocate a new `ByteBuffer` with enough space to fit the bytes of the `DispatchData` and potentially
@@ -850,7 +850,7 @@ extension ByteBufferAllocator {
         return newBuffer
     }
 
-    #if canImport(Dispatch)
+    #if canImport(Dispatch) || os(WASI) // TODO: SM: Figure out import scheme for canImport(Dispatch)
     /// Create a fresh `ByteBuffer` containing the bytes contained in the given `DispatchData`.
     ///
     /// This will allocate a new `ByteBuffer` with enough space to fit the bytes of the `DispatchData` and potentially

--- a/Sources/NIOCore/ByteBuffer-conversions.swift
+++ b/Sources/NIOCore/ByteBuffer-conversions.swift
@@ -50,7 +50,7 @@ extension String {
     }
 }
 
-#if canImport(Dispatch)
+#if canImport(Dispatch) || os(WASI) // TODO: SM: Figure out import scheme for canImport(Dispatch)
 extension DispatchData {
 
     /// Creates a `DispatchData` from a given `ByteBuffer`. The entire readable portion of the buffer will be read.

--- a/Sources/NIOCore/DispatchQueue+WithFuture.swift
+++ b/Sources/NIOCore/DispatchQueue+WithFuture.swift
@@ -14,7 +14,9 @@
 
 #if canImport(Dispatch)
 import Dispatch
+#endif
 
+#if canImport(Dispatch) || os(WASI) // TODO: SM: Figure out import scheme for canImport(Dispatch)
 extension DispatchQueue {
     /// Schedules a work item for immediate execution and immediately returns with an `EventLoopFuture` providing the
     /// result. For example:

--- a/Sources/NIOCore/EventLoop.swift
+++ b/Sources/NIOCore/EventLoop.swift
@@ -1415,7 +1415,7 @@ public protocol EventLoopGroup: AnyObject, _NIOPreconcurrencySendable {
     /// future or kick off some operation, use `any()`.
     func any() -> EventLoop
 
-    #if canImport(Dispatch)
+    #if canImport(Dispatch) || os(WASI) // TODO: SM: Figure out import scheme for canImport(Dispatch)
     /// Shuts down the eventloop gracefully. This function is clearly an outlier in that it uses a completion
     /// callback instead of an EventLoopFuture. The reason for that is that NIO's EventLoopFutures will call back on an event loop.
     /// The virtue of this function is to shut the event loop down. To work around that we call back on a DispatchQueue
@@ -1443,10 +1443,11 @@ extension EventLoopGroup {
     }
 }
 
-#if canImport(Dispatch)
+// TODO: SM: Figure out import scheme for canImport(Dispatch)
+#if canImport(Dispatch) || os(WASI)
 extension EventLoopGroup {
     @preconcurrency public func shutdownGracefully(_ callback: @escaping @Sendable (Error?) -> Void) {
-        self.shutdownGracefully(queue: .global(), callback)
+        self.shutdownGracefully(queue: DispatchQueue.global(), callback)
     }
 
     @available(*, noasync, message: "this can end up blocking the calling thread", renamed: "shutdownGracefully()")

--- a/Sources/NIOCore/EventLoopFuture.swift
+++ b/Sources/NIOCore/EventLoopFuture.swift
@@ -1867,7 +1867,7 @@ extension EventLoopFuture {
 
 // MARK: may block
 
-#if canImport(Dispatch)
+#if canImport(Dispatch) || os(WASI) // TODO: SM: Figure out import scheme for canImport(Dispatch)
 extension EventLoopFuture {
     /// Chain an `EventLoopFuture<NewValue>` providing the result of a IO / task that may block. For example:
     ///

--- a/Sources/NIOCore/TemporaryExperimentalWasmShims/CAddressInfo.swift
+++ b/Sources/NIOCore/TemporaryExperimentalWasmShims/CAddressInfo.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if os(WASI)
+import CNIOWASI
+
+// TODO: SM: I should make a swifty api so I don't need to call freeaddrinfo. Unless I need to call freeaddrinfo with the underlying wasilibc api
+
+package typealias addrinfo = CAddressInfo
+package class CAddressInfo {
+
+    package let ai_socktype: Int32
+    package let ai_protocol: Int32
+    package var pointee: CAddressInfo {
+        self
+    }
+
+    package let ai_addr: UnsafePointer<sockaddr>?
+    package let ai_family: Int32
+
+    package let ai_next: CAddressInfo?
+
+    package init(
+        ai_socktype: Int32,
+        ai_protocol: Int32
+    ) {
+        // TODO: SM: Implement everything and store real values here
+        self.ai_socktype = ai_socktype
+        self.ai_protocol = ai_protocol
+        self.ai_addr = nil
+        self.ai_family = 0
+
+        self.ai_next = nil
+    }
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo
+package func getaddrinfo(host: String, port: String, hint: CAddressInfo) -> CAddressInfo? {
+    // TODO: SM: Implement getaddrinfo
+    nil
+}
+
+package func freeaddrinfo(_: CAddressInfo) {
+    // This is a noop for this shim's implementation, since it uses a struct and swifty api's.
+}
+
+#endif // os(WASI)
+
+

--- a/Sources/NIOCore/TemporaryExperimentalWasmShims/CAddressInfo.swift
+++ b/Sources/NIOCore/TemporaryExperimentalWasmShims/CAddressInfo.swift
@@ -23,6 +23,7 @@ package class CAddressInfo {
     package let ai_socktype: Int32
     package let ai_protocol: Int32
     package var pointee: CAddressInfo {
+        fatalError("Not yet implemented")
         self
     }
 
@@ -35,6 +36,7 @@ package class CAddressInfo {
         ai_socktype: Int32,
         ai_protocol: Int32
     ) {
+        fatalError("Not yet implemented")
         // TODO: SM: Implement everything and store real values here
         self.ai_socktype = ai_socktype
         self.ai_protocol = ai_protocol
@@ -47,11 +49,14 @@ package class CAddressInfo {
 
 // https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo
 package func getaddrinfo(host: String, port: String, hint: CAddressInfo) -> CAddressInfo? {
+    fatalError("Not yet implemented")
     // TODO: SM: Implement getaddrinfo
-    nil
+    return nil
 }
 
 package func freeaddrinfo(_: CAddressInfo) {
+    // TODO: SM: Depending on implementation, this might not be able to be a no-op.
+    
     // This is a noop for this shim's implementation, since it uses a struct and swifty api's.
 }
 

--- a/Sources/NIOCore/TemporaryExperimentalWasmShims/Dispatch.swift
+++ b/Sources/NIOCore/TemporaryExperimentalWasmShims/Dispatch.swift
@@ -1,0 +1,85 @@
+//
+//  Dispatch.swift
+//  swift-nio
+//
+//  Created by Scott Marchant on 3/28/25.
+//
+
+#if os(WASI)
+
+import CNIOWASI
+
+// TODO: SM: Quite a bit to implement here. The plan is to use Swift Concurrency
+// as the backing for these wrapper functions. For the most part, there should be
+// enough overlap to make things function, except for blocking API's such as
+// `DispatchQueue.main.sync`. Though for those, we may be able to use
+// semaphores from Posix to make a blocking API.
+
+public class DispatchQueue: @unchecked Sendable { // TODO: SM: Make this an actor? And provide non-async functions on the actor?
+    public static let main = DispatchQueue() // SM: Figure this out
+
+    private static let _global = DispatchQueue() // SM: Figure this out
+    public static func global() -> DispatchQueue {
+        Self._global
+    }
+
+    public enum Attributes {
+        case concurrent
+    }
+
+    // SM: NOTE: DispatchQueue.init looks like this in libdispatch:
+    // init(label: String, qos: DispatchQoS = .unspecified, attributes: DispatchQueue.Attributes = [], autoreleaseFrequency: DispatchQueue.AutoreleaseFrequency = .inherit, target: DispatchQueue? = nil)
+
+    public init(label: String? = nil, attributes: DispatchQueue.Attributes? = nil, target: DispatchQueue? = nil) {
+
+    }
+
+    public func async(execute work: @escaping @Sendable @convention(block) () -> Void) {
+
+    }
+}
+
+// TODO: SM: Audit all #if canImport(Dispatch), I can either make Dispatch a module named "Dispatch", or else modify all of those closures.
+// TODO: SM: Write test for this similar to code in https://dev.to/fmo91/dispatchgroup-in-swift-gg7
+public class DispatchGroup: @unchecked Sendable {
+    public func enter() {}
+    public func leave() {}
+
+    // NOTE: We can NOT support a wait function very easily with async-await. Would need to use a semaphore or something.
+
+    public func notify(queue: DispatchQueue, execute work: @escaping @convention(block) () -> Void) {}
+
+    public init() {}
+
+} // TODO: SM: Actor? APIs
+
+// TODO: SM: Update the following comment
+// TODO: SM: Could I implement this with a posix semaphore?
+
+///
+/// This is essentially a HACK that allows compiling Swift to wasm
+/// while the real DispatchSemaphore implementation is implemented.
+/// This relies on the fact that everything in wasm lives on the
+/// single main thread.
+public class DispatchSemaphore: @unchecked Sendable {
+    public var value: Int
+
+    public init(value: Int) {
+        self.value = value
+    }
+
+    @discardableResult
+    public func signal() -> Int {
+        MainActor.assertIsolated()
+        value += 1
+        return value
+    }
+
+    public func wait() {
+        MainActor.assertIsolated()
+        assert(value > 0)
+        value -= 1
+    }
+}
+
+#endif // os(WASI)

--- a/Sources/NIOCore/TemporaryExperimentalWasmShims/Dispatch.swift
+++ b/Sources/NIOCore/TemporaryExperimentalWasmShims/Dispatch.swift
@@ -27,27 +27,69 @@ public class DispatchQueue: @unchecked Sendable { // TODO: SM: Make this an acto
         case concurrent
     }
 
+    private let target: DispatchQueue?
+
     // SM: NOTE: DispatchQueue.init looks like this in libdispatch:
     // init(label: String, qos: DispatchQoS = .unspecified, attributes: DispatchQueue.Attributes = [], autoreleaseFrequency: DispatchQueue.AutoreleaseFrequency = .inherit, target: DispatchQueue? = nil)
 
     public init(label: String? = nil, attributes: DispatchQueue.Attributes? = nil, target: DispatchQueue? = nil) {
-
+        // TODO: SM: label, attributes, etc?
+        self.target = target
     }
 
     public func async(execute work: @escaping @Sendable @convention(block) () -> Void) {
-
+        if let target = target {
+            // Recursively execute the async block on
+            target.async(execute: work)
+        } else {
+            Task {
+                work()
+            }
+        }
     }
 }
 
 // TODO: SM: Audit all #if canImport(Dispatch), I can either make Dispatch a module named "Dispatch", or else modify all of those closures.
 // TODO: SM: Write test for this similar to code in https://dev.to/fmo91/dispatchgroup-in-swift-gg7
 public class DispatchGroup: @unchecked Sendable {
-    public func enter() {}
-    public func leave() {}
+    private struct WaitingBlock {
+        let queue: DispatchQueue
+        let work: @Sendable () -> Void
+
+        init(queue: DispatchQueue, work: @escaping @Sendable @convention(block) () -> Void) {
+            self.queue = queue
+            self.work = work
+        }
+    }
+    // TODO: SM: Thread safety
+
+    private var activeCount = 0 {
+        didSet {
+            if activeCount <= 0 {
+                blocksWaitingNotify.forEach { block in
+                    // TODO: SM: Warnings about sendability violations here
+                    block.queue.async(execute: block.work)
+                }
+                blocksWaitingNotify.removeAll()
+            }
+        }
+    }
+    public func enter() {
+        activeCount += 1
+    }
+
+    public func leave() {
+        activeCount -= 1
+    }
+
+    private var blocksWaitingNotify: [WaitingBlock] = []
 
     // NOTE: We can NOT support a wait function very easily with async-await. Would need to use a semaphore or something.
 
-    public func notify(queue: DispatchQueue, execute work: @escaping @convention(block) () -> Void) {}
+    public func notify(queue: DispatchQueue, execute work: @escaping @Sendable @convention(block) () -> Void) {
+        // TODO: SM: What happens if nothing is waiting? Should I immediately schedule, or never execute?
+        blocksWaitingNotify.append(WaitingBlock(queue: queue, work: work))
+    }
 
     public init() {}
 
@@ -82,4 +124,48 @@ public class DispatchSemaphore: @unchecked Sendable {
     }
 }
 
+// TODO: SM: HACK: This is probably not thread safe, but
+// for wasm, it shouldn't matter right now.
+import struct FoundationEssentials.Data
+public typealias DispatchData = Data
+
 #endif // os(WASI)
+
+//sm: leftoffhere:
+//
+//Trying to run this code, the wasm fails to compile (invalid). Also fails running from node.
+//
+//Not sure where problem is. Start by looking up tools to debug/disassemble the wasm binary. From node, the problem may
+//be a mismatch of function parameters. Hopefully I can isolate the file, comment it out, and make it compile on wasm.
+//
+//Preferably don't want to play big game of needles and haystacks.
+//
+//Might need to enable WASI 0.2 both in my toolchain and in wasmtime for this to finally work.
+//
+//
+//
+//
+//
+//
+//wasm-tools validate NIOWebSocketClient.wasm
+//error: func 1076 failed to validate
+//
+//Caused by:
+//    0: type mismatch: expected i32 but nothing on stack (at offset 0x7def7)
+//
+//
+//
+//
+//
+//
+//node
+//Welcome to Node.js v22.14.0.
+//Type ".help" for more information.
+//> const wasmBuffer = fs.readFileSync('/Users/scottm/git/ThirdParty/swift-nio/.build/wasm32-unknown-wasip1-threads/debug/NIOWebSocketClient.wasm');
+//undefined
+//> fined
+//Uncaught ReferenceError: fined is not defined
+//> let mod = await WebAssembly.compile(wasmBuffer)
+//Uncaught:
+//CompileError: WebAssembly.compile(): Compiling function #1076:"$ss9UnmanagedV7AtomicsE6retain2byySi_tF" failed: not enough arguments on the stack for call (need 4, got 2) @+515831
+//> 

--- a/Sources/NIOCore/TemporaryExperimentalWasmShims/WASICPoll.swift
+++ b/Sources/NIOCore/TemporaryExperimentalWasmShims/WASICPoll.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if os(WASI)
+
+import CNIOWASI
+
+// TODO: SM: Implement a wrapper to poll from CNIOWASI
+// that performs a similar function as epoll. Obviously
+// it will be less efficient. But it should work
+
+@usableFromInline
+package struct WASICPoll {
+    @usableFromInline
+    package struct poll_event {
+        @usableFromInline
+        package init() {
+            // TODO: SM: Implement all the things!
+        }
+    }
+    @usableFromInline
+    package init() {
+        // TODO: SM: Implement all the things!
+    }
+}
+
+#endif // os(WASI)

--- a/Sources/NIOCore/TemporaryExperimentalWasmShims/WASICPoll.swift
+++ b/Sources/NIOCore/TemporaryExperimentalWasmShims/WASICPoll.swift
@@ -26,11 +26,13 @@ package struct WASICPoll {
     package struct poll_event {
         @usableFromInline
         package init() {
+            fatalError("Not yet implemented")
             // TODO: SM: Implement all the things!
         }
     }
     @usableFromInline
     package init() {
+        fatalError("Not yet implemented")
         // TODO: SM: Implement all the things!
     }
 }

--- a/Sources/NIOEmbedded/AsyncTestingChannel.swift
+++ b/Sources/NIOEmbedded/AsyncTestingChannel.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Dispatch)
+#if canImport(Dispatch) || os(WASI) // TODO: SM: Figure out import scheme for canImport(Dispatch)
 import NIOConcurrencyHelpers
 import NIOCore
 

--- a/Sources/NIOEmbedded/AsyncTestingEventLoop.swift
+++ b/Sources/NIOEmbedded/AsyncTestingEventLoop.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Dispatch)
+#if canImport(Dispatch) || os(WASI) // TODO: SM: Figure out import scheme for canImport(Dispatch)
 import Atomics
 
 #if canImport(Darwin)

--- a/Sources/NIOEmbedded/Embedded.swift
+++ b/Sources/NIOEmbedded/Embedded.swift
@@ -305,7 +305,7 @@ public final class EmbeddedEventLoop: EventLoop, CustomStringConvertible {
         }
     }
 
-    #if canImport(Dispatch)
+    #if canImport(Dispatch) || os(WASI) // TODO: SM: Figure out import scheme for canImport(Dispatch)
     /// - see: `EventLoop.shutdownGracefully`
     public func shutdownGracefully(queue: DispatchQueue, _ callback: @escaping (Error?) -> Void) {
         self.checkCorrectThread()

--- a/Sources/NIOFileSystem/DirectoryEntries.swift
+++ b/Sources/NIOFileSystem/DirectoryEntries.swift
@@ -12,8 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Darwin)
 import CNIODarwin
+#elseif os(Linux)
 import CNIOLinux
+#elseif os(WASI)
+#if canImport(WASILibc)
+@preconcurrency import WASILibc
+#endif
+import CNIOWASI
+#endif
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOPosix
@@ -554,6 +562,8 @@ private struct DirectoryEnumerator: Sendable {
                 // Empty is checked for above, root can't exist within a directory, and directory
                 // items must be a single path component.
                 name = FilePath.Component(platformString: CNIODarwin_dirent_dname(entry))!
+                #elseif os(WASI)
+                name = FilePath.Component(platformString: CNIOWASI_dirent_dname(entry))!
                 #else
                 name = FilePath.Component(platformString: CNIOLinux_dirent_dname(entry))!
                 #endif

--- a/Sources/NIOFileSystem/Internal/System Calls/CInterop.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/CInterop.swift
@@ -26,6 +26,8 @@ import CNIOLinux
 #elseif canImport(Android)
 @preconcurrency import Android
 import CNIOLinux
+#elseif canImport(WASILibc)
+@preconcurrency import WASILibc
 #endif
 
 /// Aliases for platform-dependent types used for system calls.
@@ -38,6 +40,8 @@ extension CInterop {
     public typealias Stat = Musl.stat
     #elseif canImport(Android)
     public typealias Stat = Android.stat
+    #elseif canImport(WASILibc)
+    public typealias Stat = WASILibc.stat
     #endif
 
     #if canImport(Darwin)
@@ -52,11 +56,14 @@ extension CInterop {
     #elseif canImport(Android)
     @_spi(Testing)
     public static let maxPathLength = Android.PATH_MAX
+    #elseif canImport(WASILibc)
+    @_spi(Testing)
+    public static let maxPathLength = WASILibc.PATH_MAX
     #endif
 
     #if canImport(Darwin)
     typealias DirPointer = UnsafeMutablePointer<Darwin.DIR>
-    #elseif canImport(Glibc) || canImport(Musl) || canImport(Android)
+    #elseif canImport(Glibc) || canImport(Musl) || canImport(Android) || canImport(WASILibc)
     typealias DirPointer = OpaquePointer
     #endif
 
@@ -68,6 +75,9 @@ extension CInterop {
     typealias DirEnt = Musl.dirent
     #elseif canImport(Android)
     typealias DirEnt = Android.dirent
+    #elseif canImport(WASILibc)
+    // typealias DirEnt = WASILibc.dirent
+    typealias DirEnt = Bool
     #endif
 
     #if canImport(Darwin)
@@ -76,6 +86,9 @@ extension CInterop {
     #elseif canImport(Glibc) || canImport(Musl) || canImport(Android)
     typealias FTS = CNIOLinux.FTS
     typealias FTSEnt = CNIOLinux.FTSENT
+    #elseif canImport(WASILibc)
+    typealias FTS = WASILibc.FTS
+    typealias FTSEnt = WASILibc.FTSENT
     #endif
 
     typealias FTSPointer = UnsafeMutablePointer<FTS>

--- a/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
+++ b/Sources/NIOFileSystem/Internal/System Calls/Syscall.swift
@@ -26,6 +26,8 @@ import CNIOLinux
 #elseif canImport(Bionic)
 @preconcurrency import Bionic
 import CNIOLinux
+#elseif canImport(WASILibc)
+import WASILibc
 #endif
 
 @_spi(Testing)
@@ -108,7 +110,7 @@ public enum Syscall {
     }
     #endif
 
-    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic) || canImport(WASILibc)
     @_spi(Testing)
     public static func rename(
         from old: FilePath,
@@ -150,7 +152,7 @@ public enum Syscall {
     }
     #endif
 
-    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic) || canImport(WASILibc)
     @_spi(Testing)
     public struct LinkAtFlags: OptionSet {
         @_spi(Testing)
@@ -255,7 +257,7 @@ public enum Syscall {
         }
     }
 
-    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic) || canImport(WASILibc)
     @_spi(Testing)
     public static func sendfile(
         to output: FileDescriptor,

--- a/Sources/NIOPosix/BSDSocketAPICommon.swift
+++ b/Sources/NIOPosix/BSDSocketAPICommon.swift
@@ -27,6 +27,10 @@ import let WinSDK.SOCK_STREAM
 import struct WinSDK.socklen_t
 #endif
 
+#if os(WASI)
+import CNIOWASI
+#endif
+
 protocol _SocketShutdownProtocol {
     var cValue: CInt { get }
 }
@@ -86,6 +90,7 @@ extension NIOBSDSocket.SocketType {
         NIOBSDSocket.SocketType(rawValue: SOCK_STREAM)
     #endif
 
+    #if !os(WASI)
     #if os(Linux) && !canImport(Musl)
     internal static let raw: NIOBSDSocket.SocketType =
         NIOBSDSocket.SocketType(rawValue: CInt(SOCK_RAW.rawValue))
@@ -93,6 +98,7 @@ extension NIOBSDSocket.SocketType {
     internal static let raw: NIOBSDSocket.SocketType =
         NIOBSDSocket.SocketType(rawValue: SOCK_RAW)
     #endif
+    #endif // !os(WASI)
 }
 
 // IPv4 Options
@@ -235,6 +241,7 @@ protocol _BSDSocketProtocol {
         length len: size_t
     ) throws -> IOResult<size_t>
 
+    #if !os(WASI)
     // NOTE: this should return a `ssize_t`, however, that is not a standard
     // type, and defining that type is difficult.  Opt to return a `size_t`
     // which is the same size, but is unsigned.
@@ -254,6 +261,7 @@ protocol _BSDSocketProtocol {
         flags: CInt
     )
         throws -> IOResult<size_t>
+    #endif // !os(WASI)
 
     static func send(
         socket s: NIOBSDSocket.Handle,
@@ -277,6 +285,7 @@ protocol _BSDSocketProtocol {
         protocolSubtype: NIOBSDSocket.ProtocolSubtype
     ) throws -> NIOBSDSocket.Handle
 
+    #if !os(WASI)
     static func recvmmsg(
         socket: NIOBSDSocket.Handle,
         msgvec: UnsafeMutablePointer<MMsgHdr>,
@@ -291,6 +300,7 @@ protocol _BSDSocketProtocol {
         vlen: CUnsignedInt,
         flags: CInt
     ) throws -> IOResult<Int>
+    #endif // !os(WASI)
 
     // NOTE: this should return a `ssize_t`, however, that is not a standard
     // type, and defining that type is difficult.  Opt to return a `size_t`

--- a/Sources/NIOPosix/BSDSocketAPIPosix.swift
+++ b/Sources/NIOPosix/BSDSocketAPIPosix.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import NIOCore
 
-#if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin)
+#if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin) || os(WASI)
 
 extension Shutdown {
     internal var cValue: CInt {
@@ -102,6 +102,7 @@ extension NIOBSDSocket {
         try Posix.read(descriptor: s, pointer: buf, size: len)
     }
 
+    #if !os(WASI)
     static func recvmsg(
         socket: NIOBSDSocket.Handle,
         msgHdr: UnsafeMutablePointer<msghdr>,
@@ -121,6 +122,7 @@ extension NIOBSDSocket {
     {
         try Posix.sendmsg(descriptor: socket, msgHdr: msgHdr, flags: flags)
     }
+    #endif // !os(WASI)
 
     static func send(
         socket s: NIOBSDSocket.Handle,
@@ -158,6 +160,7 @@ extension NIOBSDSocket {
         try Posix.socket(domain: af, type: type, protocolSubtype: protocolSubtype)
     }
 
+    #if !os(WASI)
     static func recvmmsg(
         socket: NIOBSDSocket.Handle,
         msgvec: UnsafeMutablePointer<MMsgHdr>,
@@ -187,6 +190,7 @@ extension NIOBSDSocket {
             flags: flags
         )
     }
+    #endif // !os(WASI)
 
     // NOTE: this should return a `ssize_t`, however, that is not a standard
     // type, and defining that type is difficult.  Opt to return a `size_t`
@@ -269,6 +273,14 @@ private let CMSG_DATA = CNIODarwin_CMSG_DATA
 private let CMSG_DATA_MUTABLE = CNIODarwin_CMSG_DATA_MUTABLE
 private let CMSG_SPACE = CNIODarwin_CMSG_SPACE
 private let CMSG_LEN = CNIODarwin_CMSG_LEN
+#elseif os(WASI)
+import CNIOWASI
+private let CMSG_FIRSTHDR = CNIOWASI_CMSG_FIRSTHDR
+private let CMSG_NXTHDR = CNIOWASI_CMSG_NXTHDR
+private let CMSG_DATA = CNIOWASI_CMSG_DATA
+private let CMSG_DATA_MUTABLE = CNIOWASI_CMSG_DATA_MUTABLE
+private let CMSG_SPACE = CNIOWASI_CMSG_SPACE
+private let CMSG_LEN = CNIOWASI_CMSG_LEN
 #else
 import CNIOLinux
 private let CMSG_FIRSTHDR = CNIOLinux_CMSG_FIRSTHDR

--- a/Sources/NIOPosix/BaseSocket.swift
+++ b/Sources/NIOPosix/BaseSocket.swift
@@ -287,9 +287,13 @@ class BaseSocket: BaseSocketProtocol {
         if level == .tcp && name == .tcp_nodelay {
             switch try? self.localAddress().protocol {
             case .some(.inet), .some(.inet6): break
+            
+            #if !os(WASI)
             // Setting TCP_NODELAY on UNIX domain sockets will fail. Previously we had a bug where we would ignore
             // most socket options settings so for the time being we'll just ignore this. Let's revisit for NIO 2.0.
             case .some(.unix): return
+            #endif
+
             // We'll also ignore this option on socket protocol families that NIO doesn't explicitly support.
             case .some(_), .none: return
             }

--- a/Sources/NIOPosix/Bootstrap.swift
+++ b/Sources/NIOPosix/Bootstrap.swift
@@ -2341,6 +2341,7 @@ public final class NIOPipeBootstrap {
         #endif
     }
 
+    #if !os(WASI) // WASI doesn't support Posix.dup right now
     /// Create the `PipeChannel` with the provided file descriptor which is used for both input & output.
     ///
     /// This method is useful for specialilsed use-cases where you want to use `NIOPipeBootstrap` for say a serial line.
@@ -2362,6 +2363,7 @@ public final class NIOPipeBootstrap {
             throw error
         }
     }
+    #endif // !os(WASI)
 
     /// Create the `PipeChannel` with the provided input and output file descriptors.
     ///
@@ -2439,10 +2441,12 @@ public final class NIOPipeBootstrap {
         )
     }
 
+    #if !os(WASI)
     @available(*, deprecated, renamed: "takingOwnershipOfDescriptor(inputOutput:)")
     public func withInputOutputDescriptor(_ fileDescriptor: CInt) -> EventLoopFuture<Channel> {
         self.takingOwnershipOfDescriptor(inputOutput: fileDescriptor)
     }
+    #endif
 
     @available(*, deprecated, renamed: "takingOwnershipOfDescriptors(input:output:)")
     public func withPipes(inputDescriptor: CInt, outputDescriptor: CInt) -> EventLoopFuture<Channel> {
@@ -2453,6 +2457,7 @@ public final class NIOPipeBootstrap {
 // MARK: Arbitrary payload
 
 extension NIOPipeBootstrap {
+    #if !os(WASI) // WASI doesn't support Posix.dup right now
     /// Create the `PipeChannel` with the provided file descriptor which is used for both input & output.
     ///
     /// This method is useful for specialilsed use-cases where you want to use `NIOPipeBootstrap` for say a serial line.
@@ -2486,6 +2491,7 @@ extension NIOPipeBootstrap {
             throw error
         }
     }
+    #endif // end !os(WASI)
 
     /// Create the `PipeChannel` with the provided input and output file descriptors.
     ///

--- a/Sources/NIOPosix/ControlMessage.swift
+++ b/Sources/NIOPosix/ControlMessage.swift
@@ -17,6 +17,8 @@ import NIOCore
 import CNIODarwin
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import CNIOLinux
+#elseif os(WASI)
+import CNIOWASI
 #elseif os(Windows)
 import CNIOWindows
 #endif

--- a/Sources/NIOPosix/DatagramVectorReadManager.swift
+++ b/Sources/NIOPosix/DatagramVectorReadManager.swift
@@ -15,6 +15,10 @@ import CNIODarwin
 import CNIOLinux
 import NIOCore
 
+#if os(WASI)
+import CNIOWASI
+#endif
+
 /// An object that manages issuing vector reads for datagram channels.
 ///
 /// Datagram channels have slightly complex read semantics, as high-throughput datagram
@@ -77,6 +81,7 @@ struct DatagramVectorReadManager {
         self.controlMessageStorage = controlMessageStorage
     }
 
+    #if !os(WASI)
     /// Performs a socket vector read.
     ///
     /// This method takes a single byte buffer and segments it into `messageCount` pieces. It then
@@ -156,6 +161,7 @@ struct DatagramVectorReadManager {
             )
         }
     }
+    #endif // !os(WASI)
 
     /// Destroys this vector read manager, rendering it impossible to re-use. Use of the vector read manager after this is called is not possible.
     mutating func deallocate() {

--- a/Sources/NIOPosix/GetaddrinfoResolver.swift
+++ b/Sources/NIOPosix/GetaddrinfoResolver.swift
@@ -31,6 +31,8 @@ import Dispatch
 
 #if os(Linux) || os(FreeBSD) || os(Android)
 import CNIOLinux
+#elseif os(WASI)
+import CNIOWASI
 #endif
 
 #if os(Windows)

--- a/Sources/NIOPosix/Linux.swift
+++ b/Sources/NIOPosix/Linux.swift
@@ -84,7 +84,7 @@ internal enum EventFd {
 @usableFromInline
 internal enum Epoll {
     @usableFromInline
-    internal typealias epoll_event = CNIOLinux.epoll_event
+    internal typealias epoll_event = CNIOLinux.epoll_event // TODO: SM: Make sure we do NOT use CNIOLinux for wasm build (conditionalize it's usage)
 
     @usableFromInline
     internal static let EPOLL_CTL_ADD: CInt = numericCast(CNIOLinux.EPOLL_CTL_ADD)

--- a/Sources/NIOPosix/PendingDatagramWritesManager.swift
+++ b/Sources/NIOPosix/PendingDatagramWritesManager.swift
@@ -17,6 +17,10 @@ import CNIODarwin
 import CNIOLinux
 import NIOCore
 
+#if os(WASI)
+import CNIOWASI
+#endif
+
 private struct PendingDatagramWrite {
     var data: ByteBuffer
     var promise: Optional<EventLoopPromise<Void>>

--- a/Sources/NIOPosix/Pool.swift
+++ b/Sources/NIOPosix/Pool.swift
@@ -12,6 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(WASI)
+import CNIOWASI
+#endif
+
 protocol PoolElement {
     init()
     func evictedFromPool()

--- a/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
+++ b/Sources/NIOPosix/PosixSingletons+ConcurrencyTakeOver.swift
@@ -15,6 +15,10 @@
 import Atomics
 import NIOCore
 
+#if os(WASI)
+import CNIOWASI
+#endif
+
 private protocol SilenceWarning {
     @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
     func enqueue(_ job: UnownedJob)

--- a/Sources/NIOPosix/RawSocketBootstrap.swift
+++ b/Sources/NIOPosix/RawSocketBootstrap.swift
@@ -11,6 +11,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if !os(WASI) // SOCK_RAW is currently elided in waslibc's sys/socket.h
 import NIOCore
 
 /// A `RawSocketBootstrap` is an easy way to interact with IP based protocols other then TCP and UDP.
@@ -377,3 +379,5 @@ extension NIORawSocketBootstrap {
 
 @available(*, unavailable)
 extension NIORawSocketBootstrap: Sendable {}
+
+#endif // !os(WASI)

--- a/Sources/NIOPosix/SelectableEventLoop.swift
+++ b/Sources/NIOPosix/SelectableEventLoop.swift
@@ -14,7 +14,9 @@
 
 import Atomics
 import DequeModule
+#if canImport(Dispatch)
 import Dispatch
+#endif
 import NIOConcurrencyHelpers
 import NIOCore
 import _NIODataStructures

--- a/Sources/NIOPosix/SelectorWASIPoll.swift
+++ b/Sources/NIOPosix/SelectorWASIPoll.swift
@@ -1,0 +1,77 @@
+// TODO: SM: Header
+
+import NIOConcurrencyHelpers
+import NIOCore
+
+#if os(WASI)
+import CNIOWASI
+
+// NOTE: SM: Look at SelectorEpoll.swift for ideas on how to implement this
+// Will need to use the `poll` function`, which is available. It will be
+// less efficient, but should work for small descriptor numbers
+
+extension Selector: _SelectorBackendProtocol {
+    func initialiseState0() throws {
+        // TODO: SM: Implement this
+    }
+
+    func deinitAssertions0() {
+        // TODO: SM: Implement this
+    }
+
+    func register0(
+        selectableFD: CInt,
+        fileDescriptor: CInt,
+        interested: SelectorEventSet,
+        registrationID: SelectorRegistrationID
+    ) throws {
+        // TODO: SM: Implement this
+    }
+
+    func reregister0(
+        selectableFD: CInt,
+        fileDescriptor: CInt,
+        oldInterested: SelectorEventSet,
+        newInterested: SelectorEventSet,
+        registrationID: SelectorRegistrationID
+    ) throws {
+        // TODO: SM: Implement this
+    }
+
+    func deregister0(
+        selectableFD: CInt,
+        fileDescriptor: CInt,
+        oldInterested: SelectorEventSet,
+        registrationID: SelectorRegistrationID
+    ) throws {
+        // TODO: SM: Implement this
+    }
+
+    /// Apply the given `SelectorStrategy` and execute `body` once it's complete (which may produce `SelectorEvent`s to handle).
+    ///
+    /// - Parameters:
+    ///   - strategy: The `SelectorStrategy` to apply
+    ///   - body: The function to execute for each `SelectorEvent` that was produced.
+    @inlinable
+    func whenReady0(
+        strategy: SelectorStrategy,
+        onLoopBegin loopStart: () -> Void,
+        _ body: (SelectorEvent<R>) throws -> Void
+    ) throws {
+        // TODO: SM: Implement this
+    }
+
+    /// Close the `Selector`.
+    ///
+    /// After closing the `Selector` it's no longer possible to use it.
+    public func close0() throws {
+        // TODO: SM: Implement this
+    }
+
+    // attention, this may (will!) be called from outside the event loop, ie. can't access mutable shared state (such as `self.open`)
+    func wakeup0() throws {
+        // TODO: SM: Implement this
+    }
+}
+
+#endif // os(WASI)

--- a/Sources/NIOPosix/SelectorWASIPoll.swift
+++ b/Sources/NIOPosix/SelectorWASIPoll.swift
@@ -13,10 +13,12 @@ import CNIOWASI
 extension Selector: _SelectorBackendProtocol {
     func initialiseState0() throws {
         // TODO: SM: Implement this
+        fatalError("Not yet implemented")
     }
 
     func deinitAssertions0() {
         // TODO: SM: Implement this
+        fatalError("Not yet implemented")
     }
 
     func register0(
@@ -26,6 +28,7 @@ extension Selector: _SelectorBackendProtocol {
         registrationID: SelectorRegistrationID
     ) throws {
         // TODO: SM: Implement this
+        fatalError("Not yet implemented")
     }
 
     func reregister0(
@@ -36,6 +39,7 @@ extension Selector: _SelectorBackendProtocol {
         registrationID: SelectorRegistrationID
     ) throws {
         // TODO: SM: Implement this
+        fatalError("Not yet implemented")
     }
 
     func deregister0(
@@ -45,6 +49,7 @@ extension Selector: _SelectorBackendProtocol {
         registrationID: SelectorRegistrationID
     ) throws {
         // TODO: SM: Implement this
+        fatalError("Not yet implemented")
     }
 
     /// Apply the given `SelectorStrategy` and execute `body` once it's complete (which may produce `SelectorEvent`s to handle).
@@ -59,6 +64,7 @@ extension Selector: _SelectorBackendProtocol {
         _ body: (SelectorEvent<R>) throws -> Void
     ) throws {
         // TODO: SM: Implement this
+        fatalError("Not yet implemented")
     }
 
     /// Close the `Selector`.
@@ -66,11 +72,13 @@ extension Selector: _SelectorBackendProtocol {
     /// After closing the `Selector` it's no longer possible to use it.
     public func close0() throws {
         // TODO: SM: Implement this
+        fatalError("Not yet implemented")
     }
 
     // attention, this may (will!) be called from outside the event loop, ie. can't access mutable shared state (such as `self.open`)
     func wakeup0() throws {
         // TODO: SM: Implement this
+        fatalError("Not yet implemented")
     }
 }
 

--- a/Sources/NIOPosix/ServerSocket.swift
+++ b/Sources/NIOPosix/ServerSocket.swift
@@ -49,12 +49,18 @@ class ServerSocket: BaseSocket, ServerSocketProtocol {
             protocolSubtype: protocolSubtype,
             setNonBlocking: setNonBlocking
         )
+        #if os(WASI)
+        // No .unix case currently provided in WASILibc
+        cleanupOnClose = false
+        #else
         switch protocolFamily {
         case .unix:
             cleanupOnClose = true
         default:
             cleanupOnClose = false
         }
+        #endif
+
         try super.init(socket: sock)
     }
 

--- a/Sources/NIOPosix/Socket.swift
+++ b/Sources/NIOPosix/Socket.swift
@@ -171,6 +171,7 @@ class Socket: BaseSocket, SocketProtocol {
         }
     }
 
+    #if !os(WASI)
     /// Send data to a destination.
     ///
     /// - Parameters:
@@ -230,6 +231,7 @@ class Socket: BaseSocket, SocketProtocol {
             }
         }
     }
+    #endif // !os(WASI)
 
     /// Read data from the socket.
     ///
@@ -243,6 +245,7 @@ class Socket: BaseSocket, SocketProtocol {
         }
     }
 
+    #if !os(WASI)
     /// Receive data from the socket, along with aditional control information.
     ///
     /// - Parameters:
@@ -314,6 +317,7 @@ class Socket: BaseSocket, SocketProtocol {
             }
         }
     }
+    #endif // !os(WASI)
 
     /// Send the content of a file descriptor to the remote peer (if possible a zero-copy strategy is applied).
     ///
@@ -334,6 +338,7 @@ class Socket: BaseSocket, SocketProtocol {
         }
     }
 
+    #if !os(WASI)
     /// Receive `MMsgHdr`s.
     ///
     /// - Parameters:
@@ -368,6 +373,7 @@ class Socket: BaseSocket, SocketProtocol {
             )
         }
     }
+    #endif // !os(WASI)
 
     /// Shutdown the socket.
     ///

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -38,6 +38,12 @@ internal typealias in6_pktinfo = CNIOLinux_in6_pktinfo
 import CNIOWindows
 
 internal typealias MMsgHdr = CNIOWindows_mmsghdr
+#elseif os(WASI)
+#if canImport(WASILibc)
+@_exported @preconcurrency import WASILibc
+#endif
+import CNIOWASI
+internal typealias MMsgHdr = CNIOWASI_mmsghdr
 #else
 #error("The POSIX system module was unable to identify your C library.")
 #endif
@@ -81,11 +87,27 @@ let S_IFBLK = UInt32(SwiftGlibc.S_IFBLK)
 #endif
 #endif
 
+// sm: leftoffhere: Figure out where we are using a socket, and whether we're using nio for the socket.
+// 
+// there appears to be support for it. https://github.com/WebAssembly/WASI/blob/main/wasip2/README.md
+// see also /Users/scottm/Library/org.swift.swiftpm/swift-sdks/swift-wasm-6.1-SNAPSHOT-2025-03-20-a-wasm32-unknown-wasip1-threads.artifactbundle/6.1-SNAPSHOT-2025-03-20-a-wasm32-unknown-wasip1-threads/wasm32-unknown-wasip1-threads/WASI.sdk/include/wasm32-wasip1-threads/sys/socket.h
+// 
+// I might just need to add some more includes, or else wrap the definitions in my shim.c. Usage of bind seems to compile in my c file. Maybe it needs forwarded somehow?
+// 
+// or maybe there is a different swift import?
+// 
+// 
+// See also /Users/scottm/Library/org.swift.swiftpm/swift-sdks/swift-wasm-6.1-SNAPSHOT-2025-03-20-a-wasm32-unknown-wasip1-threads.artifactbundle/6.1-SNAPSHOT-2025-03-20-a-wasm32-unknown-wasip1-threads/wasm32-unknown-wasip1-threads/swift.xctoolchain/usr/lib/swift/wasi/WASILibc.swiftmodule
+// 
+// try to do a wrapper similar to sendmmsg, but for sysBind. If that works, then I have a path forward on a lot of this.
+
+
 // Declare aliases to share more code and not need to repeat #if #else blocks
+
 #if !os(Windows)
 private let sysClose = close
 private let sysShutdown = shutdown
-private let sysBind = bind
+private let sysBind: @Sendable (Int32, UnsafePointer<sockaddr>?, socklen_t) -> Int32 = bind
 private let sysFcntl: @Sendable @convention(c) (CInt, CInt, CInt) -> CInt = { fcntl($0, $1, $2) }
 private let sysSocket = socket
 private let sysSetsockopt = setsockopt
@@ -129,11 +151,13 @@ private let sysWritev: @convention(c) (Int32, UnsafePointer<iovec>?, CInt) -> CL
 #if canImport(Android)
 private let sysRecvMsg: @convention(c) (CInt, UnsafeMutablePointer<msghdr>, CInt) -> ssize_t = recvmsg
 private let sysSendMsg: @convention(c) (CInt, UnsafePointer<msghdr>, CInt) -> ssize_t = sendmsg
-#elseif !os(Windows)
+#elseif !os(Windows) && !os(WASI)
 private let sysRecvMsg: @convention(c) (CInt, UnsafeMutablePointer<msghdr>?, CInt) -> ssize_t = recvmsg
 private let sysSendMsg: @convention(c) (CInt, UnsafePointer<msghdr>?, CInt) -> ssize_t = sendmsg
 #endif
+#if !os(WASI)
 private let sysDup: @convention(c) (CInt) -> CInt = dup
+#endif
 #if canImport(Android)
 private let sysGetpeername:
     @convention(c) (CInt, UnsafeMutablePointer<sockaddr>, UnsafeMutablePointer<socklen_t>) -> CInt = getpeername
@@ -148,16 +172,16 @@ private let sysGetsockname:
 
 #if os(Android)
 private let sysIfNameToIndex: @convention(c) (UnsafePointer<CChar>) -> CUnsignedInt = if_nametoindex
-#else
+#elseif !os(WASI)
 private let sysIfNameToIndex: @convention(c) (UnsafePointer<CChar>?) -> CUnsignedInt = if_nametoindex
 #endif
 #if canImport(Android)
 private let sysSocketpair: @convention(c) (CInt, CInt, CInt, UnsafeMutablePointer<CInt>) -> CInt = socketpair
-#elseif !os(Windows)
+#elseif !os(Windows) && !os(WASI)
 private let sysSocketpair: @convention(c) (CInt, CInt, CInt, UnsafeMutablePointer<CInt>?) -> CInt = socketpair
 #endif
 
-#if os(Linux) || os(Android) || canImport(Darwin)
+#if os(Linux) || os(Android) || canImport(Darwin) || os(WASI)
 private let sysFstat = fstat
 private let sysStat = stat
 private let sysLstat = lstat
@@ -353,7 +377,7 @@ internal func syscall<T>(
         }
     }
 }
-#elseif os(Linux) || os(Android)
+#elseif os(Linux) || os(Android) || os(WASI)
 @inline(__always)
 @inlinable
 @discardableResult
@@ -456,7 +480,7 @@ internal enum Posix: Sendable {
     static let SHUT_WR: CInt = CInt(Darwin.SHUT_WR)
     @usableFromInline
     static let SHUT_RDWR: CInt = CInt(Darwin.SHUT_RDWR)
-    #elseif os(Linux) || os(FreeBSD) || os(Android)
+    #elseif os(Linux) || os(FreeBSD) || os(Android) || os(WASI)
     #if canImport(Glibc)
     @usableFromInline
     static let UIO_MAXIOV: Int = Int(Glibc.UIO_MAXIOV)
@@ -484,6 +508,14 @@ internal enum Posix: Sendable {
     static let SHUT_WR: CInt = CInt(Android.SHUT_WR)
     @usableFromInline
     static let SHUT_RDWR: CInt = CInt(Android.SHUT_RDWR)
+    #elseif canImport(CNIOWASI)
+    static let UIO_MAXIOV: Int = Int(UIO_MAXIOV)
+    @usableFromInline
+    static let SHUT_RD: CInt = CInt(SHUT_RD)
+    @usableFromInline
+    static let SHUT_WR: CInt = CInt(SHUT_WR)
+    @usableFromInline
+    static let SHUT_RDWR: CInt = CInt(SHUT_RDWR)
     #endif
     #else
     @usableFromInline
@@ -526,6 +558,12 @@ internal enum Posix: Sendable {
     static let IPTOS_ECN_ECT0: CInt = CInt(0x02)
     static let IPTOS_ECN_ECT1: CInt = CInt(0x01)
     static let IPTOS_ECN_CE: CInt = CInt(0x03)
+    #elseif os(WASI)
+    static let IPTOS_ECN_NOTECT: CInt = CInt(IPTOS_ECN_NOTECT)
+    static let IPTOS_ECN_MASK: CInt = CInt(IPTOS_ECN_MASK)
+    static let IPTOS_ECN_ECT0: CInt = CInt(IPTOS_ECN_ECT0)
+    static let IPTOS_ECN_ECT1: CInt = CInt(IPTOS_ECN_ECT1)
+    static let IPTOS_ECN_CE: CInt = CInt(IPTOS_ECN_CE)
     #endif
 
     #if canImport(Darwin)
@@ -540,6 +578,12 @@ internal enum Posix: Sendable {
 
     static let IPV6_RECVPKTINFO: CInt = CInt(CNIOLinux.IPV6_RECVPKTINFO)
     static let IPV6_PKTINFO: CInt = CInt(CNIOLinux.IPV6_PKTINFO)
+    #elseif os(WASI)
+    static let IP_RECVPKTINFO: CInt = CInt(IPV6_RECVPKTINFO)
+    static let IP_PKTINFO: CInt = CInt(IP_PKTINFO)
+
+    static let IPV6_RECVPKTINFO: CInt = CInt(IPV6_RECVPKTINFO)
+    static let IPV6_PKTINFO: CInt = CInt(IPV6_PKTINFO)
     #elseif os(Windows)
     static let IP_PKTINFO: CInt = CInt(WinSDK.IP_PKTINFO)
 
@@ -744,6 +788,7 @@ internal enum Posix: Sendable {
         }
     }
 
+    #if !os(WASI)
     @inline(never)
     public static func recvmsg(
         descriptor: CInt,
@@ -754,6 +799,7 @@ internal enum Posix: Sendable {
             sysRecvMsg(descriptor, msgHdr, flags)
         }
     }
+    
 
     @inline(never)
     public static func sendmsg(
@@ -765,6 +811,7 @@ internal enum Posix: Sendable {
             sysSendMsg(descriptor, msgHdr, flags)
         }
     }
+    #endif // !os(WASI)
 
     @discardableResult
     @inline(never)
@@ -775,6 +822,7 @@ internal enum Posix: Sendable {
     }
     #endif
 
+    #if !os(WASI)
     @discardableResult
     @inline(never)
     public static func dup(descriptor: CInt) throws -> CInt {
@@ -782,6 +830,7 @@ internal enum Posix: Sendable {
             sysDup(descriptor)
         }.result
     }
+    #endif
 
     #if !os(Windows)
     // It's not really posix but exists on Linux and MacOS / BSD so just put it here for now to keep it simple
@@ -823,6 +872,7 @@ internal enum Posix: Sendable {
         }
     }
 
+    #if !os(WASI)
     @inline(never)
     public static func sendmmsg(
         sockfd: CInt,
@@ -847,6 +897,7 @@ internal enum Posix: Sendable {
             Int(sysRecvMmsg(sockfd, msgvec, vlen, flags, timeout))
         }
     }
+    #endif // !os(WASI)
 
     @inline(never)
     public static func getpeername(
@@ -871,12 +922,14 @@ internal enum Posix: Sendable {
     }
     #endif
 
+    #if !os(WASI)
     @inline(never)
     public static func if_nametoindex(_ name: UnsafePointer<CChar>?) throws -> CUnsignedInt {
         try syscall(blocking: false) {
             sysIfNameToIndex(name!)
         }.result
     }
+    #endif
 
     #if !os(Windows)
     @inline(never)
@@ -967,7 +1020,7 @@ internal enum Posix: Sendable {
             sysClosedir(dir)
         }
     }
-    #elseif os(Linux) || os(FreeBSD) || os(Android)
+    #elseif os(Linux) || os(FreeBSD) || os(Android) || os(WASI)
     @inline(never)
     public static func opendir(pathname: String) throws -> OpaquePointer {
         try syscall {
@@ -1004,6 +1057,7 @@ internal enum Posix: Sendable {
         }
     }
 
+    #if !os(WASI)
     @inline(never)
     public static func socketpair(
         domain: NIOBSDSocket.ProtocolFamily,
@@ -1015,6 +1069,7 @@ internal enum Posix: Sendable {
             sysSocketpair(domain.rawValue, type.rawValue, protocolSubtype.rawValue, socketVector!)
         }
     }
+    #endif // !os(WASI)
     #endif
     #if !os(Windows)
     @inline(never)

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -535,7 +535,7 @@ internal enum Posix: Sendable {
     static let IPV6_RECVPKTINFO: CInt = CNIODarwin_IPV6_RECVPKTINFO
     static let IPV6_PKTINFO: CInt = CNIODarwin_IPV6_PKTINFO
     #elseif os(Linux) || os(FreeBSD) || os(Android)
-    static let IP_RECVPKTINFO: CInt = CInt(CNIOLinux.IP_PKTINFO)
+    static let IP_RECVPKTINFO: CInt = CInt(CNIOLinux.IP_PKTINFO) // SM: This is probably a bug, should be `= CNIOLinux.IP_RECVPKTINFO`
     static let IP_PKTINFO: CInt = CInt(CNIOLinux.IP_PKTINFO)
 
     static let IPV6_RECVPKTINFO: CInt = CInt(CNIOLinux.IPV6_RECVPKTINFO)

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -106,6 +106,36 @@ let S_IFBLK = UInt32(SwiftGlibc.S_IFBLK)
 
 // Declare aliases to share more code and not need to repeat #if #else blocks
 
+// TODO: sm: BIG PROBLEM: linker errors getting socket to compile AND link.
+// See https://app.clickup.com/t/86b4jtf95
+/*
+Root problem is that swift wasm toolchain doesn't have preview 2 libs in their sdk yet. I can research that. But it's involved.
+I tried compiling the swift wasm toolchain in /Users/scottm/git/ThirdParty/swiftwasm-source/swiftwasm-build, but ran into atomics error
+
+Options
+- See if nio websocketclient will work using nioembedded
+- Look through dependencies and see how critical the web socket dependency is. Especially in vapor.
+- swift/uWasi??
+- Look at webworker project in swiftwasm. They are using that in production.
+- Best option is to compile preview 2 and get this to work
+- It's worth sending the linker errors to and my findings on which c imports compile to Max in my nioposix PR. Figure out why he thinks there isn't support.
+- If I don't need websockets in our dependency chain, then nuke it out of the build for now. Maybe I can get some of the non-socket examples working for proving whether this will work
+*/
+
+// TODO: SM: Explore linker errors for following. Likely due to swift wasm toolchain using wasi preview 1, but it needs wasi preview 2
+
+// HACK: SM: link: Seeing linker errors, using placeholder for now.
+#if os(WASI)
+private func bind(_: Int32, _: UnsafePointer<sockaddr>?, _: socklen_t) -> Int32 { fatalError("SM: link: not yet implemented") }
+private func socket(_: Int32, _: Int32, _: Int32) -> Int32 { fatalError("SM: link: not yet implemented") }
+private func setsockopt(_: Int32, _: Int32, _: Int32, _: UnsafeRawPointer?, _: socklen_t) -> Int32 { fatalError("SM: link: not yet implemented") }
+private func listen(_: Int32, _: Int32) -> Int32 { fatalError("SM: link: not yet implemented") }
+private func connect(_: Int32, _: UnsafePointer<sockaddr>?, _: socklen_t) -> Int32 { fatalError("SM: link: not yet implemented") }
+
+private func getpeername(_: CInt, _: UnsafeMutablePointer<sockaddr>?, _: UnsafeMutablePointer<socklen_t>?) -> CInt  { fatalError("SM: link: not yet implemented") }
+private func getsockname(_: CInt, _: UnsafeMutablePointer<sockaddr>?, _: UnsafeMutablePointer<socklen_t>?) -> CInt { fatalError("SM: link: not yet implemented") }
+#endif // os(WASI)
+
 #if !os(Windows)
 private let sysClose = close
 private let sysShutdown = shutdown

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -102,6 +102,8 @@ let S_IFBLK = UInt32(SwiftGlibc.S_IFBLK)
 // try to do a wrapper similar to sendmmsg, but for sysBind. If that works, then I have a path forward on a lot of this.
 
 
+// SM: for epoll, look at this: https://github.com/WebAssembly/wasi-sockets/blob/main/Posix-compatibility.md
+
 // Declare aliases to share more code and not need to repeat #if #else blocks
 
 #if !os(Windows)

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -124,18 +124,6 @@ Options
 
 // TODO: SM: Explore linker errors for following. Likely due to swift wasm toolchain using wasi preview 1, but it needs wasi preview 2
 
-// HACK: SM: link: Seeing linker errors, using placeholder for now.
-#if os(WASI)
-private func bind(_: Int32, _: UnsafePointer<sockaddr>?, _: socklen_t) -> Int32 { fatalError("SM: link: not yet implemented") }
-private func socket(_: Int32, _: Int32, _: Int32) -> Int32 { fatalError("SM: link: not yet implemented") }
-private func setsockopt(_: Int32, _: Int32, _: Int32, _: UnsafeRawPointer?, _: socklen_t) -> Int32 { fatalError("SM: link: not yet implemented") }
-private func listen(_: Int32, _: Int32) -> Int32 { fatalError("SM: link: not yet implemented") }
-private func connect(_: Int32, _: UnsafePointer<sockaddr>?, _: socklen_t) -> Int32 { fatalError("SM: link: not yet implemented") }
-
-private func getpeername(_: CInt, _: UnsafeMutablePointer<sockaddr>?, _: UnsafeMutablePointer<socklen_t>?) -> CInt  { fatalError("SM: link: not yet implemented") }
-private func getsockname(_: CInt, _: UnsafeMutablePointer<sockaddr>?, _: UnsafeMutablePointer<socklen_t>?) -> CInt { fatalError("SM: link: not yet implemented") }
-#endif // os(WASI)
-
 #if !os(Windows)
 private let sysClose = close
 private let sysShutdown = shutdown

--- a/Sources/NIOPosix/ThreadPosix.swift
+++ b/Sources/NIOPosix/ThreadPosix.swift
@@ -12,6 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(WASI)
+// HACK: SM: link: Seeing linker errors, using placeholder for now.
+
+private func HACK_pthread_getname_np(_: pthread_t, _: UnsafeMutablePointer<CChar>, _: Int) -> Int32 { fatalError("SM: link: not yet implemented") }
+private func HACK_pthread_setname_np(_ p: pthread_t, _ pointer: UnsafePointer<Int8>) -> Int32 { fatalError("SM: link: not yet implemented") }
+#endif
+
 #if os(Linux) || os(Android) || os(FreeBSD) || os(WASI) || canImport(Darwin)
 
 #if os(Linux) || os(Android)
@@ -26,8 +33,8 @@ private typealias ThreadDestructor = @convention(c) (UnsafeMutableRawPointer?) -
 #endif
 #elseif os(WASI)
 import CNIOWASI
-private let sys_pthread_getname_np = pthread_getname_np
-private let sys_pthread_setname_np = pthread_setname_np
+private let sys_pthread_getname_np = HACK_pthread_getname_np
+private let sys_pthread_setname_np = HACK_pthread_setname_np
 private typealias ThreadDestructor = @convention(c) (UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer?
 
 #elseif canImport(Darwin)

--- a/Sources/NIOPosix/ThreadPosix.swift
+++ b/Sources/NIOPosix/ThreadPosix.swift
@@ -12,13 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(WASI)
-// HACK: SM: link: Seeing linker errors, using placeholder for now.
-
-private func HACK_pthread_getname_np(_: pthread_t, _: UnsafeMutablePointer<CChar>, _: Int) -> Int32 { fatalError("SM: link: not yet implemented") }
-private func HACK_pthread_setname_np(_ p: pthread_t, _ pointer: UnsafePointer<Int8>) -> Int32 { fatalError("SM: link: not yet implemented") }
-#endif
-
 #if os(Linux) || os(Android) || os(FreeBSD) || os(WASI) || canImport(Darwin)
 
 #if os(Linux) || os(Android)
@@ -33,8 +26,8 @@ private typealias ThreadDestructor = @convention(c) (UnsafeMutableRawPointer?) -
 #endif
 #elseif os(WASI)
 import CNIOWASI
-private let sys_pthread_getname_np = HACK_pthread_getname_np
-private let sys_pthread_setname_np = HACK_pthread_setname_np
+private let sys_pthread_getname_np = pthread_getname_np
+private let sys_pthread_setname_np = pthread_setname_np
 private typealias ThreadDestructor = @convention(c) (UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer?
 
 #elseif canImport(Darwin)


### PR DESCRIPTION
NOTE: This is a DRAFT targetting my own fork for now. **This is highly experimental and not functional in its current form.** But NIOPosix does compile to wasm with the changes in this PR.

To get this to compile, I have implemented empty wrappers for the following functionality. Due to the empty wrapper implementation, all functionality relying on these API surface areas is broken. I have a path forward to implement the functionality in a way that compiles to wasm as noted:

- [ ] `Dispatch` does not compile. Very well-documented SwiftWasm issue. To work around this, I plan to implement the wrapper with a Swift Concurrency backing. As far as I can tell, there is enough overlap with Swift Concurrency to allow this.
- [ ] `Epoll` is not available and is required. For the wrapper, I plan to use `poll`, which is available. It will be less efficient for large numbers of descriptors, but should work.
- [ ] `getaddrinfo` is not available and is required. Wasi preview 2 has some solutions for a limited data set. I plan to implement the wrapper using the API available in WASI. It will have a more limited scope compared to `getaddrinfo`.

For `Dispatch`, there are a few integration options.

1. Bring my lite Dispatch (aka `DispatchLite`) into the SwiftWasm toolchain. This is ideal, as anything that does `import Dispatch` or `#if canImport(Dispatch)` would automatically do the "right" thing, assuming the `DispatchLite` implementation has an implementation for the Dispatch API being used.
2. I can provide my `DispatchLite` as a separate SPM library in it's own repo, and consume it as a dependency. Unless we integrate into the SwifWasm toolchain, I would want to do this anyways for the Dispatch usages in Vapor and RxSwift. I am pretty sure the apple swift-nio team won't allow a third-party dependency, though. And they would not want to bring a `DispatchLite` into their own house, either.
3. My `DispatchLite` implementation may be small enough to be a single-file library. That may be the only option for swift-nio. And other repos can use option 2.




_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
